### PR TITLE
Refactor URL parsing and build version variable

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -7,6 +7,8 @@ vars:
     sh: go env GOOS
   GOARCH:
     sh: go env GOARCH
+  GIT_COMMIT:
+    sh: git rev-parse HEAD
 
 tasks:
   default:
@@ -18,17 +20,11 @@ tasks:
     desc: Builds the binary into the project root
     cmds:
       - GOARCH={{.GOARCH}} GOOS={{.GOOS}} go build -o . -ldflags="-X main.version={{.GIT_COMMIT}}" ./...
-    vars:
-      GIT_COMMIT:
-        sh: git rev-parse HEAD
 
   install:
     desc: Installs the package into the Go bin directory
     cmds:
       - go install -ldflags="-X main.version={{.GIT_COMMIT}}" ./...
-    vars:
-      GIT_COMMIT:
-        sh: git rev-parse HEAD
 
   clean:
     desc: Removes build artifacts

--- a/internal/urls/urls.go
+++ b/internal/urls/urls.go
@@ -10,14 +10,11 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+var scpSyntaxRegex = regexp.MustCompile(`^([a-zA-Z0-9_]+)@([a-zA-Z0-9._-]+):(.*)$`)
+
 // IsScpSyntax takes a string url and returns true if the url is in scp format
 func IsScpSyntax(url string) bool {
-	scpSyntax := regexp.MustCompile(`^([a-zA-Z0-9_]+)@([a-zA-Z0-9._-]+):(.*)$`)
-	match := scpSyntax.FindStringSubmatch(url)
-	if match != nil {
-		return true
-	}
-	return false
+	return scpSyntaxRegex.FindStringSubmatch(url) != nil
 }
 
 // ConvertScpURL converts scp syntax urls into ssh transport urls


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Build/install behavior is unchanged; URL logic is equivalent with a minor performance improvement from reusing the compiled regex.
> 
> **Overview**
> **Taskfile:** `GIT_COMMIT` is defined once in top-level `vars` instead of being duplicated under the `build` and `install` tasks. Both tasks still inject it via `-ldflags="-X main.version={{.GIT_COMMIT}}"`.
> 
> **URL parsing:** SCP-style detection now uses a package-level `scpSyntaxRegex` compiled with `regexp.MustCompile` instead of recompiling the pattern on every `IsScpSyntax` call. `IsScpSyntax` is reduced to checking whether `FindStringSubmatch` returns a match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d82cf8974c8eb9bc1e394f635c09ebf1ae68b8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->