### PR TITLE
Configure Renovate automerge for patch and minor updates

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -4,11 +4,6 @@ permissions:
 name: Go
 on:
   pull_request:
-    paths:
-      - "**.go"
-      - "go.mod"
-      - "Taskfile.yml"
-      - ".github/workflows/go.yaml"
 
 jobs:
   ci:

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,12 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["patch", "minor"],
+      "automerge": true,
+      "automergeType": "pr"
+    }
   ]
 }


### PR DESCRIPTION
## Summary

- Enables automerge for Renovate PRs covering patch and minor version bumps
- Uses PR-based automerge (`automergeType: "pr"`) so GitHub's branch protection rules (required status checks) gate the merge
- Major version bumps continue to require manual review and merge