### PR TITLE
Add goreleaser release pipeline

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,33 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run goreleaser
+        uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
+        with:
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /git-get
+dist/
+.task/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -21,10 +21,12 @@ builds:
 
 archives:
   - name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
-    format: tar.gz
+    formats:
+      - tar.gz
     format_overrides:
       - goos: windows
-        format: zip
+        formats:
+          - zip
     files:
       - LICENSE
       - README.md

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,57 @@
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+version: 2
+
+project_name: git-get
+
+builds:
+  - main: ./
+    binary: git-get
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w
+      - -X main.version={{ .Version }}
+
+archives:
+  - name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    format: tar.gz
+    format_overrides:
+      - goos: windows
+        format: zip
+    files:
+      - LICENSE
+      - README.md
+
+checksum:
+  name_template: "checksums.txt"
+
+changelog:
+  sort: asc
+  use: github
+  groups:
+    - title: "Features"
+      regexp: "^feat(\\([^\\)]+\\))?!?:.*$"
+      order: 0
+    - title: "Bug Fixes"
+      regexp: "^fix(\\([^\\)]+\\))?!?:.*$"
+      order: 1
+    - title: "Other"
+      order: 999
+  filters:
+    exclude:
+      - "^docs:"
+      - "^chore:"
+      - "^ci:"
+      - "Merge pull request"
+      - "Merge branch"
+
+release:
+  prerelease: auto
+  name_template: "{{ .ProjectName }} {{ .Version }}"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -41,3 +41,8 @@ tasks:
     cmds:
       - go test ./... -cover -race
       - govulncheck ./...
+
+  snapshot:
+    desc: Builds a local multi-platform snapshot using goreleaser (no publish)
+    cmds:
+      - goreleaser release --snapshot --clean


### PR DESCRIPTION
## Summary

- Adds `.goreleaser.yaml` to build cross-platform binaries (linux/darwin/windows × amd64/arm64) and publish them as GitHub Release assets on every `v*` tag push
- Adds `.github/workflows/release.yaml` triggered by semver tag pushes
- Adds `task snapshot` to Taskfile for local multi-platform test builds without publishing
- Updates `.gitignore` to exclude `dist/` and `.task/`

## What ships on each release

6 archives (`tar.gz` for Unix, `zip` for Windows), each containing the binary + `LICENSE` + `README.md`, plus a `checksums.txt`. The semver tag is embedded in the binary via ldflags (`-X main.version={{ .Version }}`), replacing the commit-hash approach used by local dev builds.

## Security

- Workflow permissions scoped to job level (`contents: write` only on the release job; workflow-level default is `contents: read`)
- All actions pinned to commit SHAs
- `v*` tag creation/update/deletion restricted to repo admins via GitHub tag ruleset (ID 17640678)

## Test plan

- [x] Run `task snapshot` locally — confirm `dist/` contains 6 archives across all platforms
- [x] Merge to main, push a test tag (`git tag v0.1.0 && git push origin v0.1.0`), verify the Actions run completes and the release appears at `github.com/jackson-hughes/git-get/releases`
- [x] Download one binary, run with `GIT_GET_DEBUG=true` and confirm the version string shows the tag value