### PR TITLE
Fix URL handling bugs and harden CLI behaviour

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -28,11 +28,17 @@ jobs:
         run: go mod download
 
       - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.5.0
         if: matrix.go-version == 'stable'
 
       - name: Build
         run: go build -v ./...
+
+      - name: Lint
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
+        with:
+          version: v2.12.2
+        if: matrix.go-version == 'stable'
 
       - name: Test
         run: go test -v ./... -cover -race

--- a/README.md
+++ b/README.md
@@ -13,18 +13,23 @@ Produces:
 
 ## Installation
 
-Clone the repository and either build the binary or install the binary to `$GOBIN`.
+Install directly with Go:
 
-The [Taskfile](https://taskfile.dev/) provides build and install commands, e.g:
+    go install github.com/jackson-hughes/git-get@latest
+
+Alternatively, clone the repository and build or install from source. The [Taskfile](https://taskfile.dev/) provides build and install commands, e.g:
 
     task install
 
-Or simply:
-
-    go install
-
 ## Config
 
-Set the root directory that `git-get` will use by setting the `GIT_GET_DIR` environment variable. I set mine in my `~/.zshrc`, e.g:
+`git-get` is configured via environment variables:
+
+| Variable | Required | Description |
+| --- | --- | --- |
+| `GIT_GET_DIR` | Yes | Root directory that repositories are cloned into |
+| `GIT_GET_DEBUG` | No | Set to `true` to enable debug logging |
+
+I set `GIT_GET_DIR` in my `~/.zshrc`, e.g:
 
     export GIT_GET_DIR="$HOME/Projects"

--- a/config.go
+++ b/config.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"os"
-
 	"github.com/kelseyhightower/envconfig"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
@@ -10,16 +8,20 @@ import (
 
 type Specification struct {
 	Debug bool
-	Dir   string `default:"/tmp"`
+	Dir   string
 }
 
 var appConfig Specification
 
-var version string
+var version = "dev"
 
-func init() {
+func loadConfig() {
 	if err := envconfig.Process("git_get", &appConfig); err != nil {
-		log.Fatal().Msgf("error loading config:\n %v", err)
+		log.Fatal().Err(err).Msg("Error loading config")
+	}
+
+	if appConfig.Dir == "" {
+		log.Fatal().Msg(`GIT_GET_DIR is not set; set the clone root directory, e.g. export GIT_GET_DIR="$HOME/Projects"`)
 	}
 
 	if appConfig.Debug {
@@ -28,7 +30,6 @@ func init() {
 	} else {
 		zerolog.SetGlobalLevel(zerolog.InfoLevel)
 	}
-	log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
 
 	log.Debug().Msgf("version: %v", version)
 	log.Debug().Msgf("config: %+v", appConfig)

--- a/git-get.go
+++ b/git-get.go
@@ -1,63 +1,79 @@
 package main
 
 import (
+	"flag"
 	"fmt"
-	"git-get/internal/urls"
-	"net/url"
 	"os"
 	"os/exec"
 
+	"github.com/jackson-hughes/git-get/internal/urls"
+	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 )
 
 func displayHelp() {
 	helpMessage := `git-get is a simple utility that clones git repositories into a go get style directory structure.
 
-git-get accepts one argument, the git project url to clone, for example:
-	git-get https://github.com/jackson-hughes/git-get.git`
-	fmt.Println(helpMessage)
+Usage:
+	git-get <repository-url>
+
+Example:
+	git-get https://github.com/jackson-hughes/git-get.git
+
+Flags:
+	-h, --help	display this help message
+	--version	print the version and exit
+
+Configuration:
+	GIT_GET_DIR	(required) root directory to clone repositories into
+	GIT_GET_DEBUG	set to true to enable debug logging`
+	fmt.Fprintln(os.Stderr, helpMessage)
 }
 
-func clone(gitProjectURL url.URL, gitProjectsDir string) error {
-	cmd := exec.Command("git", "clone", gitProjectURL.String(), gitProjectsDir)
+func clone(rawURL string, targetDir string) error {
+	cmd := exec.Command("git", "clone", rawURL, targetDir)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
-		return err
-	}
-	return nil
+	return cmd.Run()
 }
 
 func main() {
-	if len(os.Args) != 2 {
-		displayHelp()
+	log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
+
+	flag.Usage = displayHelp
+	showVersion := flag.Bool("version", false, "print the version and exit")
+	flag.Parse()
+
+	if *showVersion {
+		fmt.Println(version)
 		return
 	}
+
+	if flag.NArg() != 1 {
+		displayHelp()
+		os.Exit(2)
+	}
+
+	loadConfig()
 
 	if err := validateGitExists(exec.LookPath); err != nil {
 		log.Fatal().Err(err).Send()
 	}
 
-	gitProjectURL := os.Args[1]
+	rawURL := flag.Arg(0)
 
-	var gitURL url.URL
-
-	if ok := urls.IsScpSyntax(gitProjectURL); ok {
-		URL, err := urls.ConvertScpURL(gitProjectURL)
-		if err != nil {
-			log.Fatal().Err(err).Send()
-		}
-		gitURL = *URL
-	} else {
-		URL, err := url.Parse(gitProjectURL)
-		if err != nil {
-			log.Fatal().Err(err).Send()
-		}
-		gitURL = *URL
+	// The parsed URL is used only to derive the target directory; the
+	// original input is what gets passed to git clone.
+	gitURL, err := urls.Parse(rawURL)
+	if err != nil {
+		log.Fatal().Err(err).Msg("Invalid repository URL")
 	}
 
-	projectFilepath := urls.GetFilepathFromURL(gitURL, appConfig.Dir)
-	log.Debug().Msgf("input url: %v", gitURL.String())
+	projectFilepath, err := urls.GetFilepathFromURL(*gitURL, appConfig.Dir)
+	if err != nil {
+		log.Fatal().Err(err).Msg("Error determining target directory")
+	}
+	log.Debug().Msgf("input url: %v", rawURL)
 	log.Debug().Msgf("path to write repo to: %v", projectFilepath)
 
 	exists, err := checkDirectoryExists(projectFilepath)
@@ -68,7 +84,7 @@ func main() {
 		log.Fatal().Msgf("Target directory already exists: %s", projectFilepath)
 	}
 
-	if err := clone(gitURL, projectFilepath); err != nil {
+	if err := clone(rawURL, projectFilepath); err != nil {
 		log.Fatal().Err(err).Msg("Error cloning repository")
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module git-get
+module github.com/jackson-hughes/git-get
 
 go 1.25.0
 

--- a/internal/urls/urls.go
+++ b/internal/urls/urls.go
@@ -10,40 +10,62 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-var scpSyntaxRegex = regexp.MustCompile(`^([a-zA-Z0-9_]+)@([a-zA-Z0-9._-]+):(.*)$`)
+var scpSyntaxRegex = regexp.MustCompile(`^([a-zA-Z0-9._-]+)@([a-zA-Z0-9._-]+):(.*)$`)
 
-// IsScpSyntax takes a string url and returns true if the url is in scp format
-func IsScpSyntax(url string) bool {
-	return scpSyntaxRegex.FindStringSubmatch(url) != nil
+// Parse parses a user-supplied repository URL, converting scp syntax urls
+// (git@github.com:org/repo.git) to ssh transport form. It returns an error
+// if the url cannot be parsed or has no host.
+func Parse(rawURL string) (*url.URL, error) {
+	var u *url.URL
+	var err error
+	if isScpSyntax(rawURL) {
+		u, err = convertScpURL(rawURL)
+	} else {
+		u, err = url.Parse(rawURL)
+	}
+	if err != nil {
+		return nil, err
+	}
+	if u.Host == "" {
+		return nil, fmt.Errorf("could not determine host from %q; expected a URL like https://github.com/org/repo.git or git@github.com:org/repo.git", rawURL)
+	}
+	return u, nil
 }
 
-// ConvertScpURL converts scp syntax urls into ssh transport urls
+// isScpSyntax takes a string url and returns true if the url is in scp format
+func isScpSyntax(url string) bool {
+	return scpSyntaxRegex.MatchString(url)
+}
+
+// convertScpURL converts scp syntax urls into ssh transport urls
 // git@github.com:jackson-hughes/git-get.git -> ssh://git@github.com/jackson-hughes/git-get
-func ConvertScpURL(scpSyntaxUrl string) (*url.URL, error) {
-	log.Debug().Msgf("ConvertScpURL: received input %v: ", scpSyntaxUrl)
+func convertScpURL(scpSyntaxUrl string) (*url.URL, error) {
+	log.Debug().Msgf("convertScpURL: received input %v", scpSyntaxUrl)
 	path := strings.Replace(scpSyntaxUrl, ":", "/", 1)
 	path = strings.TrimSuffix(path, ".git")
 	convertedURL, err := url.Parse(fmt.Sprintf("ssh://%v", path))
 	if err != nil {
 		return nil, err
 	}
-	log.Debug().Msgf("ConvertScpURL: returned %v: ", convertedURL)
+	log.Debug().Msgf("convertScpURL: returned %v", convertedURL)
 	return convertedURL, nil
 }
 
-// GetFilepathFromURL determines the go get style filepath based on the git url
-func GetFilepathFromURL(url url.URL, gitProjectRoot string) string {
-	gitHost := url.Host
-	// trim port from filepath
-	if strings.Contains(gitHost, ":") {
-		gitHost = strings.Split(url.Host, ":")[0]
-		log.Debug().Msgf("port found in hostname, %v has been replaced with %v", url.Host, gitHost)
-	}
-	gitProject := strings.TrimSuffix(url.Path, ".git")
+// GetFilepathFromURL determines the go get style filepath based on the git url.
+// It returns an error if the resulting path would escape gitProjectRoot.
+func GetFilepathFromURL(u url.URL, gitProjectRoot string) (string, error) {
+	gitHost := u.Hostname()
+	gitProject := strings.TrimSuffix(u.Path, ".git")
 	gitProject = strings.TrimPrefix(gitProject, "/")
 	pathParts := []string{gitProjectRoot, gitHost}
 	if gitProject != "" {
 		pathParts = append(pathParts, strings.Split(gitProject, "/")...)
 	}
-	return filepath.Join(pathParts...)
+	target := filepath.Join(pathParts...)
+
+	rel, err := filepath.Rel(gitProjectRoot, target)
+	if err != nil || rel == "." || !filepath.IsLocal(rel) {
+		return "", fmt.Errorf("target path %s escapes the project root %s", target, gitProjectRoot)
+	}
+	return target, nil
 }

--- a/internal/urls/urls_test.go
+++ b/internal/urls/urls_test.go
@@ -6,50 +6,147 @@ import (
 	"testing"
 )
 
-func TestIsScpSyntax(t *testing.T) {
-	t.Run("scpUrlTrue", func(t *testing.T) {
-		url := "git@github.com:jackson-hughes/git-get.git"
-		match := IsScpSyntax(url)
+func TestParse(t *testing.T) {
+	tests := []struct {
+		name     string
+		rawURL   string
+		wantHost string
+		wantErr  bool
+	}{
+		{"https url", "https://github.com/jackson-hughes/git-get.git", "github.com", false},
+		{"scp url", "git@github.com:jackson-hughes/git-get.git", "github.com", false},
+		{"ssh transport url", "ssh://git@github.com/jackson-hughes/git-get", "github.com", false},
+		{"plain string with no host", "not a url at all", "", true},
+		{"bare path with no host", "/some/local/path", "", true},
+	}
 
-		if match != true {
-			t.Errorf("got %v want %v", match, true)
-		}
-	})
-
-	t.Run("notScpUrlTrue", func(t *testing.T) {
-		url := "ssh://git@github.com/jackson-hughes/git-get"
-		match := IsScpSyntax(url)
-
-		if match == true {
-			t.Errorf("got %v want %v", match, false)
-		}
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Parse(tt.rawURL)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("Parse(%q) expected error, got %v", tt.rawURL, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got.Host != tt.wantHost {
+				t.Errorf("Parse(%q).Host = %q, want %q", tt.rawURL, got.Host, tt.wantHost)
+			}
+		})
+	}
 }
 
-func TestConvertScpUrl(t *testing.T) {
-	url := "git@github.com:jackson-hughes/git-get.git"
-	want := "ssh://git@github.com/jackson-hughes/git-get"
-
-	got, err := ConvertScpURL(url)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+func TestIsScpSyntax(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		want bool
+	}{
+		{"scp url", "git@github.com:jackson-hughes/git-get.git", true},
+		{"scp url with hyphenated user", "deploy-bot@github.com:jackson-hughes/git-get.git", true},
+		{"scp url with dotted user", "first.last@github.com:jackson-hughes/git-get.git", true},
+		{"ssh transport url", "ssh://git@github.com/jackson-hughes/git-get", false},
+		{"https url", "https://github.com/jackson-hughes/git-get.git", false},
+		{"plain string", "not a url at all", false},
 	}
-	if got.String() != want {
-		t.Errorf("got %v want %v", got, want)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isScpSyntax(tt.url); got != tt.want {
+				t.Errorf("isScpSyntax(%q) = %v, want %v", tt.url, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestConvertScpURL(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		want string
+	}{
+		{"github scp url", "git@github.com:jackson-hughes/git-get.git", "ssh://git@github.com/jackson-hughes/git-get"},
+		{"scp url without .git suffix", "git@github.com:jackson-hughes/git-get", "ssh://git@github.com/jackson-hughes/git-get"},
+		{"scp url with hyphenated user", "deploy-bot@my-host.com:org/repo.git", "ssh://deploy-bot@my-host.com/org/repo"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := convertScpURL(tt.url)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got.String() != tt.want {
+				t.Errorf("convertScpURL(%q) = %q, want %q", tt.url, got.String(), tt.want)
+			}
+		})
 	}
 }
 
 func TestGetFilepathFromURL(t *testing.T) {
-	root := "/tmp"
-	repoURL, err := url.Parse("https://github.com/jackson-hughes/git-get.git")
-	if err != nil {
-		t.Fatalf("unexpected error parsing url: %v", err)
+	root := "/tmp/root"
+
+	tests := []struct {
+		name    string
+		url     string
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "https url",
+			url:  "https://github.com/jackson-hughes/git-get.git",
+			want: filepath.Join(root, "github.com", "jackson-hughes", "git-get"),
+		},
+		{
+			name: "host with port",
+			url:  "https://github.com:8443/org/repo.git",
+			want: filepath.Join(root, "github.com", "org", "repo"),
+		},
+		{
+			name: "ipv6 host with port",
+			url:  "ssh://git@[::1]:2222/org/repo.git",
+			want: filepath.Join(root, "::1", "org", "repo"),
+		},
+		{
+			name: "ssh transport url",
+			url:  "ssh://git@github.com/jackson-hughes/git-get",
+			want: filepath.Join(root, "github.com", "jackson-hughes", "git-get"),
+		},
+		{
+			name:    "path traversal escapes root",
+			url:     "https://github.com/../../../../home/user/.ssh",
+			wantErr: true,
+		},
+		{
+			name:    "path traversal resolves to root itself",
+			url:     "https://github.com/..",
+			wantErr: true,
+		},
 	}
 
-	got := GetFilepathFromURL(*repoURL, root)
-	want := filepath.Join(root, "github.com", "jackson-hughes", "git-get")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			u, err := url.Parse(tt.url)
+			if err != nil {
+				t.Fatalf("unexpected error parsing url: %v", err)
+			}
 
-	if got != want {
-		t.Errorf("GetFilepathFromURL() = %q, want %q", got, want)
+			got, err := GetFilepathFromURL(*u, root)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("GetFilepathFromURL(%q) expected error, got path %q", tt.url, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("GetFilepathFromURL(%q) = %q, want %q", tt.url, got, tt.want)
+			}
+		})
 	}
 }

--- a/validation.go
+++ b/validation.go
@@ -6,9 +6,8 @@ import (
 )
 
 func validateGitExists(lookPath func(string) (string, error)) error {
-	_, err := lookPath("git")
-	if err != nil {
-		return fmt.Errorf("git binary not found in PATH. Please install git to use git-get")
+	if _, err := lookPath("git"); err != nil {
+		return fmt.Errorf("git binary not found in PATH (install git to use git-get): %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
- Prevent cloned paths escaping GIT_GET_DIR (path traversal guard)
- Use url.Hostname() so ports and IPv6 hosts resolve correctly
- Clone the original URL as given; use parsed form only for the target path
- Reject input with no host; broaden scp regex to allow - and . in users
- Require GIT_GET_DIR (no more /tmp default); move config out of init()
- Add --version flag; exit non-zero on misuse
- Rename module to github.com/jackson-hughes/git-get for go install
- Add golangci-lint to CI, pin govulncheck; table-driven tests; update README